### PR TITLE
added steps to create local logging_config.ini file

### DIFF
--- a/deploy_notes_initial.md
+++ b/deploy_notes_initial.md
@@ -27,6 +27,9 @@
       1. Register your own [Eventbrite token](https://www.eventbrite.com/support/articles/en_US/How_To/how-to-locate-your-eventbrite-api-user-key?lg=en_US)
        1. Flask secret can be any long random string
        1. (No longer needed) Version 3 of the Meetup.com API requires an Oauth Key. However, as of Oct 2019, we're using only public GET API endpoints that require not authentication. It's not necessary to register a Meetup.com API key unless/until the app needs access to an authenticated endpoint, at which point the key could be added to the config file
+4. Create a local logging_config.ini file
+   1. `cp logging_config.ini.example logging_config.ini`
+   2. `mkdir logs`
 5. Test with gunicorn WSGI Server on a localhost port
    1. Run the following to generate / update the `all_meetsups.json` file in your application directory.
    2. cd ~/upstate_tech_cal_service && conda activate cal_service && python update_cal_data.py && conda deactivate


### PR DESCRIPTION
Apart from creating a local logging_config.ini file, I also had to add a directory `logs` because the logging_config.ini.example file that gets copied creates an error.log and access.log files in `logs/`.

I suppose you could also edit the logging_config.ini file to create these logs in the app directory, and I don't know of a reason not to. However, I went with creating a logs directory.