### PR TITLE
Fix/past meetups

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,6 @@ def get_meetup_events(group_list):
     # Create empty list to be returned by the function
     all_events = []
 
-    ## Meetup's API returns paginated results. These results have been limited to the first 50 events.
     max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
     current_time = datetime.datetime.utcnow()
     no_earlier_than = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%S.000')
@@ -70,6 +69,7 @@ def get_meetup_events(group_list):
     for api in group_apis:
         # Create url from group name found in Organization API's field_event_api_key
         url = 'https://api.meetup.com/{}/events?&sign=true&photo-host=public&no_earlier_than={}&status=upcoming,cancelled,past&page=50'.format(api, no_earlier_than)
+        ## Meetup's API returns paginated results. These results have been limited to the first 50 events.
 
         r = requests.get(url)
         if r.status_code != 200:

--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ def get_meetup_events(group_list):
     # Create empty list to be returned by the function
     all_events = []
 
+    ## Meetup's API returns paginated results. These results have been limited to the first 50 events.
     max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
     current_time = datetime.datetime.utcnow()
     no_earlier_than = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%S.000')

--- a/app.py
+++ b/app.py
@@ -65,14 +65,13 @@ def get_meetup_events(group_list):
     max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
     current_time = datetime.datetime.utcnow()
     no_earlier_than = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%S.000')
-    print('date', no_earlier_than)
+    
 
     for api in group_apis:
         # Create url from group name found in Organization API's field_event_api_key
         url = 'https://api.meetup.com/{}/events?&sign=true&photo-host=public&no_earlier_than={}&status=upcoming,cancelled,past&page=50'.format(api, no_earlier_than)
 
         r = requests.get(url)
-        # print(r.json())
         if r.status_code != 200:
             raise Exception('Could not connect to Meetup API at {}.  Status Code: {}'.format(url, r.status_code))
 

--- a/app.py
+++ b/app.py
@@ -60,11 +60,18 @@ def get_meetup_events(group_list):
     group_apis = [i['field_events_api_key'] for i in group_list]
     # Create empty list to be returned by the function
     all_events = []
+
+    max_days_in_the_past = config.get('past_events', 'max_days_in_the_past')
+    current_time = datetime.datetime.utcnow()
+    no_earlier_than = (current_time - datetime.timedelta(int(max_days_in_the_past))).strftime('%Y-%m-%dT%H:%M:%S.000')
+    print('date', no_earlier_than)
+
     for api in group_apis:
         # Create url from group name found in Organization API's field_event_api_key
-        url = 'https://api.meetup.com/{}/events?&sign=true&photo-host=public&page=20'.format(api)
+        url = 'https://api.meetup.com/{}/events?&sign=true&photo-host=public&no_earlier_than={}&status=upcoming,cancelled,past&page=50'.format(api, no_earlier_than)
 
         r = requests.get(url)
+        # print(r.json())
         if r.status_code != 200:
             raise Exception('Could not connect to Meetup API at {}.  Status Code: {}'.format(url, r.status_code))
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -9,6 +9,6 @@ username = user
 update_cal_location = /home/user/upstate_tech_cal_service/update_cal_data.py
 
 [past_events]
-max_days_in_the_past = 30
+max_days_in_the_past = 5
 default_days_in_the_past = 3
 


### PR DESCRIPTION
The URL conf for the Meetup API call has been modified to include status types of `upcoming`, `past`, and `cancelled`. 

The API now returns the first 50 results, as we are not paginating through the response. This has been noted above the API call in the code. 