### PR TITLE
Docs/fix deploy initial errors

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -4,10 +4,6 @@ secret_key = secret
 [eventbrite]
 token = ABC123
 
-[aws]
-username = user
-update_cal_location = /home/user/upstate_tech_cal_service/update_cal_data.py
-
 [past_events]
 max_days_in_the_past = 5
 default_days_in_the_past = 3

--- a/config.ini.example-docker
+++ b/config.ini.example-docker
@@ -4,10 +4,6 @@ secret_key = secret
 [eventbrite]
 token = ABC123
 
-[aws]
-username = user
-update_cal_location = /app/update_cal_data.py
-
 [past_events]
 max_days_in_the_past = 5
 default_days_in_the_past = 3

--- a/deploy_notes_initial.md
+++ b/deploy_notes_initial.md
@@ -1,3 +1,5 @@
+These steps are intended to be run the first time a development or production copy of this application is setup.
+
 1. Open a Command Prompt / Terminal / Shell, either:
    1. On your local computer / localhost
    1. Or, if you develop on a remote server then SSH into the remote machine.
@@ -10,11 +12,11 @@
       1. Ubuntu / Debian: `sudo apt-get update` && `sudo apt-get install git`
       1. Mac: `sudo brew install git`
    1. `cd` to change the directory to where you want the git repository / application to be downloaded
-   5. Clone the GitHub repository
+   5. Clone the GitHub repository, or your fork
       1. Using the SSH protocol: `git clone git@github.com:codeforgreenville/upstate_tech_cal_service.git`
       1. Or, using the HTTPS protcol: `git clone https://github.com/codeforgreenville/upstate_tech_cal_service.git`
    6. `cd upstate_tech_cal_service`
-   7. `curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh`
+   7. [Install Miniconda](https://docs.conda.io/en/latest/miniconda.html#latest-miniconda-installer-links) (Linux example) `curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh`
    8. `sh miniconda.sh -b -p $HOME/miniconda`
    9. `export PATH="$HOME/miniconda/bin:$PATH"`
    10. `conda env create -f environment.yml`
@@ -31,7 +33,7 @@
    1. `cp logging_config.ini.example logging_config.ini`
    2. `mkdir logs`
 5. Test with gunicorn WSGI Server on a localhost port
-   1. Run the following to generate / update the `all_meetsups.json` file in your application directory.
+   1. Run the following to generate / update the `all_meetups.json` file in your application directory.
    2. cd ~/upstate_tech_cal_service && conda activate cal_service && python update_cal_data.py && conda deactivate
    2. Start a "localhost" web server: `gunicorn --bind 0.0.0.0:8000 app:app`
    2. Visit the localhost application in your web browser, and see if it works: `http://localhost:8000/api/gtc?tags=1'`


### PR DESCRIPTION
Cleaning up old notes, URL, and typos.
Remove the [aws] section in the config.ini files since they are not used.