### PR TITLE
refactored format_event functions

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ def output_json(data, code, headers={"Content-Type": "application/json"}):
 
 @api.representation('application/json+ld')
 def output_json_ld(data, code, headers={"Content-Type": "application/json+ld"}):
-    events_data = func.format_ld_json(data)
+    events_data = func.format_json_ld(data)
     events_data = json.dumps(events_data)
     resp = Response(events_data, status=code, headers=headers)
     return resp

--- a/app_functions.py
+++ b/app_functions.py
@@ -31,7 +31,6 @@ def filter_events_by_date(events, start_date_str=datetime.datetime.now(datetime.
 
     if isinstance(start_date, str) or isinstance(end_date, str):
         return '{}{}'.format(start_date, end_date).replace('None', '')
-
     if start_date and end_date:
         return [event for event in events if start_date <= parse(event['time']) <= end_date]
     elif start_date:
@@ -39,7 +38,6 @@ def filter_events_by_date(events, start_date_str=datetime.datetime.now(datetime.
     elif end_date:
         return [event for event in events if parse(event['time']) <= end_date]
     else:
-        
         return events
 
 # Takes list of events and string of tags to return list of events with specified tags
@@ -54,100 +52,78 @@ def filter_events_by_tag(events, tags):
         return events
 
 def get_dates():
-    # retrieves date parameters if given
-    # if no date parameters have been given,
-    # will use current time - default days in the past (see config) for start_date
+    #  retrieves date parameters if given
+    #  if no date parameters have been given,
+    #  will use current time - default days in the past (see config) for start_date
     if request.args.get('start_date'):
         start_date = request.args.get('start_date', datetime.datetime.now(datetime.timezone.utc))
     else: 
         default_days_in_the_past = config.get('past_events', 'default_days_in_the_past')
         current_time = (datetime.datetime.utcnow())
         start_date = (current_time - datetime.timedelta(int(default_days_in_the_past))).strftime('%Y-%m-%d')
-
     end_date = request.args.get('end_date', None)
     return start_date, end_date
  
 
-def format_ld_json(events_json):
-    # function reformats all_meetings.json to ld+json 
+def format_json_ld(events_json):
+    # reformats all_meetings.json to JSON+LD 
     data_feed_elements = []
     for event in events_json:
         if event.get('venue') is not None:
-            element = {
-                "@type": "DataFeedItem",
-                "dateCreated": event.get("created_at"), 
-                "dateModified": event.get('data_as_of'),
-                "item": {
-                    "@type": "Event",
-                    "description": event.get('description'), 
-                    "name": event.get('event_name'), 
-                    "organizer": {
-                        "@type": "Organization",
-                        "name": event.get('group_name')
-                            }, 
-                    "nid": event.get('nid'),
-                    "rsvp_count": event.get('rsvp_count'),
-                    "tags": event.get('tags'), 
-                    "startDate": event.get('time'), 
-                    "url": event.get('url'), 
-                    "identifier": f"urn:uuid:{event.get('uuid')}", 
-                    "location":
-                        {
-                        "@type": "Place",
-                        "name": event.get('venue').get('name'),
-                        "address": {
-                        "streetAddress": event.get('venue').get('address'), 
-                        "addressLocality": event.get('venue').get('city'),
-                        "addressRegion": event.get('venue').get('state'),
-                        "addressCountry": event.get('venue').get('country'),
-                        "postalCode": event.get('venue').get('zip')
-                            },
-                        "geo": {
-                            "@type": "GeoCoordinates",
-                            "latitude": event.get('venue').get('lat'),
-                            "longitude": event.get('venue').get('lon'),
-                            }
-                        }
+            location = {
+                "@type": "Place",
+                "name": event.get('venue').get('name'),
+                "address": {
+                "streetAddress": event.get('venue').get('address'), 
+                "addressLocality": event.get('venue').get('city'),
+                "addressRegion": event.get('venue').get('state'),
+                "addressCountry": event.get('venue').get('country'),
+                "postalCode": event.get('venue').get('zip')
+                    },
+                "geo": {
+                    "@type": "GeoCoordinates",
+                    "latitude": event.get('venue').get('lat'),
+                    "longitude": event.get('venue').get('lon'),
                     }
                 }
         else:
-            element = {
-                "@type": "DataFeedItem",
-                "dateCreated": event.get("created_at"), 
-                "dateModified": event.get('data_as_of'),
-                "item": {
-                    "@type": "Event",
-                    "description": event.get('description'), 
-                    "name": event.get('event_name'), 
-                    "organizer": {
-                        "@type": "Organization",
-                        "name": event.get('group_name')
-                            }, 
-                    "nid": event.get('nid'),
-                    "rsvp_count": event.get('rsvp_count'),
-                    "tags": event.get('tags'), 
-                    "startDate": event.get('time'), 
-                    "url": event.get('url'), 
-                    "identifier": f"urn:uuid:{event.get('uuid')}", 
-                    "location":
-                        {
-                        "@type": "Place",
-                        "name": event['venue'],
-                        "address": {
-                        "streetAddress": None, 
-                        "addressLocality": None,
-                        "addressRegion": None,
-                        "addressCountry": None,
-                        "postalCode": None
-                            },
-                        "geo": {
-                            "@type": "GeoCoordinates",
-                            "latitude": None,
-                            "longitude": None,
-                            }
-                        }
+            location = {
+                "@type": "Place",
+                "name": event['venue'],
+                "address": {
+                "streetAddress": None, 
+                "addressLocality": None,
+                "addressRegion": None,
+                "addressCountry": None,
+                "postalCode": None
+                    },
+                "geo": {
+                    "@type": "GeoCoordinates",
+                    "latitude": None,
+                    "longitude": None,
                     }
+            }
+        element = {
+            "@type": "DataFeedItem",
+            "dateCreated": event.get("created_at"), 
+            "dateModified": event.get('data_as_of'),
+            "item": {
+                "@type": "Event",
+                "description": event.get('description'), 
+                "name": event.get('event_name'), 
+                "organizer": {
+                    "@type": "Organization",
+                    "name": event.get('group_name')
+                        }, 
+                "nid": event.get('nid'),
+                "rsvp_count": event.get('rsvp_count'),
+                "tags": event.get('tags'), 
+                "startDate": event.get('time'), 
+                "url": event.get('url'), 
+                "identifier": f"urn:uuid:{event.get('uuid')}", 
+                "location": location
                 }
+            }
         data_feed_elements.append(element)
             
             

--- a/app_functions.py
+++ b/app_functions.py
@@ -69,7 +69,13 @@ def format_json_ld(events_json):
     # reformats all_meetings.json to JSON+LD 
     data_feed_elements = []
     for event in events_json:
-        if event.get('venue') is not None:
+        # if event is online:
+        if event['venue'] is None or event['venue']['name'] == "Online event":
+            location = {
+                "@type": "VirtualLocation",
+                "url": event.get('url')
+            }
+        else:
             location = {
                 "@type": "Place",
                 "name": event.get('venue').get('name'),
@@ -86,11 +92,7 @@ def format_json_ld(events_json):
                     "longitude": event.get('venue').get('lon'),
                     }
                 }
-        else:
-            location = {
-                "@type": "VirtualLocation",
-                "url": event.get('url')
-            }
+            
         element = {
             "@type": "DataFeedItem",
             "dateCreated": event.get("created_at"), 

--- a/app_functions.py
+++ b/app_functions.py
@@ -88,20 +88,8 @@ def format_json_ld(events_json):
                 }
         else:
             location = {
-                "@type": "Place",
-                "name": event['venue'],
-                "address": {
-                "streetAddress": None, 
-                "addressLocality": None,
-                "addressRegion": None,
-                "addressCountry": None,
-                "postalCode": None
-                    },
-                "geo": {
-                    "@type": "GeoCoordinates",
-                    "latitude": None,
-                    "longitude": None,
-                    }
+                "@type": "VirtualLocation",
+                "url": event.get('url')
             }
         element = {
             "@type": "DataFeedItem",

--- a/update_functions.py
+++ b/update_functions.py
@@ -180,13 +180,12 @@ def normalize_eventbrite_status_codes(status):
 
 # Takes list of events hosted on EventBrite, list of venues, and list of all groups and returns formatted list of events
 def format_eventbrite_events(events_list, venues_list, group_list):
-
     venues = {}
     events = []
     for venue in venues_list:
         venue_id = venue.get('id')
         venue_address = venue.get('address')
-        venue_dict = {}
+        # venue_dict = {}
         if venue_address:
             venue_dict = {
                 'name': venue.get('name'),
@@ -205,32 +204,18 @@ def format_eventbrite_events(events_list, venues_list, group_list):
             group_item = [i for i in group_list if i['field_events_api_key'] == event.get('organizer_id')][0]
             group_name = group_item.get('title')
             tags = group_item.get('field_org_tags')
-            
+            # creates unique_id for events
             random.seed('meetup' + event.get('id'))
             unique_id = str(uuid.UUID(bytes=bytes(random.getrandbits(8) for _ in range(16)), version=4))
-            
             nid = group_item.get('nid')
             if type(event.get('venue_id')) == str:
-                event_dict = {
+                venue = venues[event.get('venue_id')]
+            else:
+                venue = event.get('venue_id')
+            event_dict = {
                     'event_name': event.get('name').get('text'),
                     'group_name': group_name,
-                    'venue': venues[event.get('venue_id')],
-                    'url': event.get('url'),
-                    'time': event.get('start').get("utc"),
-                    'tags': tags,
-                    'rsvp_count': None,
-                    'created_at': event.get('created'),
-                    'description': event.get('description').get('text'),
-                    'uuid': unique_id,
-                    'nid': nid,
-                    'data_as_of': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
-                    'status': normalize_eventbrite_status_codes(event.get('status'))
-                }
-            elif event.get('venue_id') == None: # if event venue is None, it is online/virtual
-                event_dict = {
-                    'event_name': event.get('name').get('text'),
-                    'group_name': group_name,
-                    'venue': event.get('venue_id'),
+                    'venue': venue,
                     'url': event.get('url'),
                     'time': event.get('start').get("utc"),
                     'tags': tags,


### PR DESCRIPTION
Both format_event functions have repeating lines of code in an if/else block. This PR moves those repeated lines to outside of the if/else block, so that nothing is being repeated unnecessarily. This is discussed in more detail in #55. 

Edit:
I just added the change to online events so that their location is in the same format as listed on [Google](https://developers.google.com/search/docs/advanced/structured-data/event#online-event) for JSON+LD.

This provides search engines with more descriptive information about online events. It also avoids a lot of useless data for such events, like the address fields that are each None.

Closes #58 