### PR TITLE
added service and service_id to in-person Eventbrite events

### DIFF
--- a/update_functions.py
+++ b/update_functions.py
@@ -224,7 +224,9 @@ def format_eventbrite_events(events_list, venues_list, group_list):
                     'uuid': unique_id,
                     'nid': nid,
                     'data_as_of': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
-                    'status': normalize_eventbrite_status_codes(event.get('status'))
+                    'status': normalize_eventbrite_status_codes(event.get('status')),
+                    'service_id': event.get('id'),
+                    'service': 'eventbrite'
                 }
             elif event.get('venue_id') == None: # if event venue is None, it is online/virtual
                 event_dict = {


### PR DESCRIPTION
There were two separate blocks of code defining the Eventbrite events JSON format. Only one of them contained the fields for `service` and `service_id`. It went unnoticed because there wasn't any in-person events. More details listed in issue #55 
Closes #55 