### PR TITLE
Downgrade urllib3 and requests packages in Pipfile because of urllib3 V2 breaking production. 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,11 +7,12 @@ name = "pypi"
 gunicorn = "*"
 flask = "*"
 simplejson = "*"
-requests = "*"
+requests = "<2.31.0"
 python-crontab = "*"
 pytz = "*"
 flask-cors = "*"
 flask-restful = "*"
+urllib3 ="<2"
 
 [requires]
 python_version = "3.9"


### PR DESCRIPTION
[As mentioned](https://github.com/hackgvl/events-api/pull/72#issuecomment-1636878434), urllib3 requires openssl v 1.1.1+, which older still supported OS, like CentOS 7, still use a version below that.

The only solution is to [upgrade the OS](https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#common-upgrading-issues) or downgrade the package.

This downgrades the package and I think locks it to this version in the Pipfile.